### PR TITLE
Allow HTMX over CORS

### DIFF
--- a/pkg/config/cors.go
+++ b/pkg/config/cors.go
@@ -4,6 +4,42 @@ import (
 	"time"
 
 	"github.com/gin-contrib/cors"
+	"go.rtnl.ai/quarterdeck/pkg/web/htmx"
+)
+
+var (
+	allowedHeaders = [14]string{
+		"Origin",
+		"Accept",
+		"Content-Length",
+		"Content-Type",
+		"Authorization",
+		"X-CSRF-TOKEN",
+		htmx.HXBoosted,
+		htmx.HXCurrentURL,
+		htmx.HXHistoryRestoreRequest,
+		htmx.HXPrompt,
+		htmx.HXRequest,
+		htmx.HXTarget,
+		htmx.HXTriggerName,
+		htmx.HXTrigger,
+	}
+	exposeHeaders = [14]string{
+		"Content-Length",
+		"Content-Type",
+		"Access-Control-Allow-Origin",
+		htmx.HXLocation,
+		htmx.HXPushURL,
+		htmx.HXRedirect,
+		htmx.HXRefresh,
+		htmx.HXReplaceURL,
+		htmx.HXReswap,
+		htmx.HXRetarget,
+		htmx.HXReselect,
+		htmx.HXTriggerAfterSettle,
+		htmx.HXTriggerAfterSwap,
+		htmx.HXTrigger,
+	}
 )
 
 func (c Config) CORS() cors.Config {
@@ -11,14 +47,15 @@ func (c Config) CORS() cors.Config {
 	return cors.Config{
 		AllowAllOrigins:        false,
 		AllowOrigins:           c.AllowOrigins,
-		AllowMethods:           []string{"GET", "HEAD", "POST", "OPTIONS"},
-		AllowHeaders:           []string{"Origin", "Content-Length", "Content-Type", "Authorization", "X-CSRF-TOKEN"},
-		ExposeHeaders:          []string{"Content-Length", "Access-Control-Allow-Origin"},
+		AllowMethods:           []string{"GET", "HEAD", "POST", "PUT", "DELETE", "OPTIONS"},
+		AllowHeaders:           allowedHeaders[:],
+		ExposeHeaders:          exposeHeaders[:],
 		AllowCredentials:       true,
 		AllowWildcard:          false,
 		AllowBrowserExtensions: false,
 		AllowWebSockets:        false,
-		AllowPrivateNetwork:    false,
+		AllowPrivateNetwork:    true,
 		MaxAge:                 12 * time.Hour,
+		CustomSchemas:          []string{"honu://"},
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -21,6 +21,7 @@ import (
 	"go.rtnl.ai/quarterdeck/pkg/config"
 	"go.rtnl.ai/quarterdeck/pkg/errors"
 	"go.rtnl.ai/quarterdeck/pkg/store"
+	"go.rtnl.ai/quarterdeck/pkg/web/scene"
 )
 
 func init() {
@@ -76,6 +77,9 @@ func New(conf config.Config) (s *Server, err error) {
 		console := zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
 		log.Logger = zerolog.New(console).With().Timestamp().Logger()
 	}
+
+	// Configure the scene for handling templates
+	scene.WithConf(conf)
 
 	// Create a new server instance and prepare to serve.
 	s = &Server{

--- a/pkg/web/htmx/htmx.go
+++ b/pkg/web/htmx/htmx.go
@@ -14,14 +14,14 @@ const (
 	HXHistoryRestoreRequest = "HX-History-Restore-Request" // “true” if the request is for history restoration after a miss in the local history cache
 	HXPrompt                = "HX-Prompt"                  // the user response to an hx-prompt
 	HXRequest               = "HX-Request"                 // always “true”
-	HXtarget                = "HX-Target"                  // the id of the target element if it exists
+	HXTarget                = "HX-Target"                  // the id of the target element if it exists
 	HXTriggerName           = "HX-Trigger-Name"            // the name of the triggered element if it exists
 )
 
 // HTMX Response Headers
 const (
 	HXLocation           = "HX-Location"             // allows you to do a client-side redirect that does not do a full page reload
-	HxPushURL            = "HX-Push-Url"             // pushes a new url into the history stack
+	HXPushURL            = "HX-Push-Url"             // pushes a new url into the history stack
 	HXRedirect           = "HX-Redirect"             // can be used to do a client-side redirect to a new location
 	HXRefresh            = "HX-Refresh"              // if set to “true” the client-side will do a full refresh of the page
 	HXReplaceURL         = "HX-Replace-Url"          // replaces the current URL in the location bar

--- a/pkg/web/scene/auth.go
+++ b/pkg/web/scene/auth.go
@@ -13,8 +13,8 @@ func (s Scene) Login(c *gin.Context) *LoginScene {
 	// Return the login scene with the default URLs set.
 	return &LoginScene{
 		Scene:             s,
-		LoginURL:          "/v1/login",
-		ForgotPasswordURL: "/forgot-password",
+		LoginURL:          loginURL,
+		ForgotPasswordURL: forgotPasswordURL,
 		Next:              c.Query("next"),
 	}
 }

--- a/pkg/web/scene/scene.go
+++ b/pkg/web/scene/scene.go
@@ -6,6 +6,8 @@ overloaded term and milieu was too hard to spell.
 package scene
 
 import (
+	"net/url"
+
 	"github.com/gin-gonic/gin"
 	"go.rtnl.ai/gimlet/auth"
 	"go.rtnl.ai/quarterdeck/pkg"
@@ -19,6 +21,11 @@ var (
 	shortVersion = pkg.Version(true)
 	revision     = pkg.GitVersion
 	buildDate    = pkg.BuildDate
+
+	// Authentication URLs
+	issuer            *url.URL
+	loginURL          string
+	forgotPasswordURL string
 )
 
 // Keys for default Scene context items
@@ -126,4 +133,8 @@ func (s Scene) HasPermission(permission string) bool {
 // Set Global Scene for Context
 //===========================================================================
 
-func WithConf(conf *config.Config) {}
+func WithConf(conf config.Config) {
+	issuer, _ = url.Parse(conf.Auth.Issuer)
+	loginURL = issuer.ResolveReference(&url.URL{Path: "/v1/login"}).String()
+	forgotPasswordURL = issuer.ResolveReference(&url.URL{Path: "/forgot-password"}).String()
+}


### PR DESCRIPTION
### Scope of changes

Allows HTMX requests over CORS to enable Endeavor login pages.

Fixes SC-33996

### Type of change

- [ ] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

This PR will be merged without review.

### Definition of Done

- [ ] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests
- [ ] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)

<!--
- [ ] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

-->
